### PR TITLE
chore(deps): bump https://github.com/majuansari/jx-go.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[majuansari/jx-go](https://github.com/majuansari/jx-go.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: majuansari
+  repo: jx-go
+  url: https://github.com/majuansari/jx-go.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/majuansari-jx-go-sr.yaml
+++ b/repositories/templates/majuansari-jx-go-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: majuansari
+    provider: github
+    repository: jx-go
+  name: majuansari-jx-go
+spec:
+  description: Imported application for majuansari/jx-go
+  httpCloneURL: https://github.com/majuansari/jx-go.git
+  org: majuansari
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jx-go
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/majuansari/jx-go.git


### PR DESCRIPTION
Update [majuansari/jx-go](https://github.com/majuansari/jx-go.git) 

Command run was `jx create quickstart --filter golang-http --git-api-token ad50a42eb29c9c961a43a293eb667dce6baba529 --project-name jx-go`